### PR TITLE
Removes use of `apt` package

### DIFF
--- a/actions.yaml
+++ b/actions.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 Canonical Ltd.
+# Copyright 2022 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 attach-ue:

--- a/actions.yaml
+++ b/actions.yaml
@@ -1,20 +1,17 @@
-# Copyright 2020 David Garcia
+# Copyright 2021 Canonical Ltd.
 # See LICENSE file for licensing details.
-#
-# This is only an example, and you should edit to suit your needs.
-# If you don't need actions, you can remove the file entirely.
-# It ties in to the example _on_fortune_action handler in src/charm.py
+
 attach-ue:
   description: Attach User Emulator to enodeB
   params:
     usim-imsi:
-      description: "USIM IMSI"
+      description: "The unique identifier of the USIM"
       type: string
     usim-k:
-      description: "USIM K"
+      description: "The secret key shared with the HSS in the EPC"
       type: string
     usim-opc:
-      description: "USIM OPC"
+      description: "The Operator Code (only used with MILENAGE algorithm)"
       type: string
   required:
     - usim-imsi

--- a/config.yaml
+++ b/config.yaml
@@ -1,8 +1,6 @@
-# Copyright 2020 David Garcia
+# Copyright 2021 Canonical Ltd.
 # See LICENSE file for licensing details.
-#
-# This is only an example, and you should edit to suit your needs.
-# If you don't need config, you can remove the file entirely.
+
 options:
   bind-address-subnet:
     type: string
@@ -13,45 +11,45 @@ options:
   enb-name:
     type: string
     description: |
-      TODO
+      eNodeB name
     default: dummyENB01
   enb-mcc:
     type: int
     description: |
-      TODO
+      EnodeB Mobile Country Code (MCC)
     default: 901
   enb-mnc:
     type: int
     description: |
-      TODO
+      EnodeB Mobile Network Code (MNC)
     default: 70
   enb-rf-device-name:
     type: string
     description: |
-      TODO
+      RF Device Name
     default: "zmq"
   enb-rf-device-args:
     type: string
     description: |
-      TODO
+      RF Device Arguments
     default: fail_on_disconnect=true,tx_port=tcp://*:2000,rx_port=tcp://localhost:2001,id=enb,base_srate=23.04e6
   ue-usim-algo:
     type: string
     description: |
-      TODO
+       The authentication algorithm to use (MILENAGE or XOR).
     default: milenage
   ue-nas-apn:
     type: string
     description: |
-      TODO
+      NAS Access Point Name (APN)
     default: oai.ipv4
   ue-device-name:
     type: string
     description: |
-      TODO
+      UE Device Name
     default: zmq
   ue-device-args:
     type: string
     description: |
-      TODO
+      UE Device arguments
     default: tx_port=tcp://*:2001,rx_port=tcp://localhost:2000,id=ue,base_srate=23.04e6

--- a/config.yaml
+++ b/config.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 Canonical Ltd.
+# Copyright 2022 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 options:

--- a/config.yaml
+++ b/config.yaml
@@ -36,7 +36,7 @@ options:
   ue-usim-algo:
     type: string
     description: |
-       The authentication algorithm to use (MILENAGE or XOR).
+      The authentication algorithm to use (MILENAGE or XOR).
     default: milenage
   ue-nas-apn:
     type: string

--- a/src/charm.py
+++ b/src/charm.py
@@ -95,7 +95,7 @@ SRS_ENB_UE_BUILD_COMMAND = f"cd {BUILD_PATH} && cmake {SRC_PATH} && make -j `npr
 
 
 class SrsLteCharm(CharmBase):
-    """Srs LTE charm."""
+    """srsRAN LTE charm."""
 
     _stored = StoredState()
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -27,7 +27,7 @@ from ops.model import ActiveStatus, MaintenanceStatus
 from utils import (
     copy_files,
     git_clone,
-    install_apt_package,
+    install_apt_packages,
     ip_from_default_iface,
     ip_from_iface,
     is_ipv4,
@@ -38,7 +38,6 @@ from utils import (
     service_stop,
     shell,
     systemctl_daemon_reload,
-    update_apt_cache,
 )
 
 logger = logging.getLogger(__name__)
@@ -133,9 +132,7 @@ class SrsLteCharm(CharmBase):
     def _on_install(self, _: InstallEvent) -> None:
         """Triggered on install event."""
         self.unit.status = MaintenanceStatus("Installing apt packages")
-        update_apt_cache()
-        for package in APT_REQUIREMENTS:
-            install_apt_package(package)
+        install_apt_packages(APT_REQUIREMENTS)
 
         self.unit.status = MaintenanceStatus("Preparing the environment")
         self._reset_environment()

--- a/src/utils.py
+++ b/src/utils.py
@@ -85,7 +85,7 @@ def _systemctl(action: str, service_name: str) -> None:
 def service_start(service_name: str) -> None:
     """Starts a given service."""
     _systemctl("start", service_name)
-    logger.info(f"Service {service_name} started")
+    logger.info("Service %s started", (service_name))
 
 
 def service_restart(service_name: str) -> None:

--- a/src/utils.py
+++ b/src/utils.py
@@ -22,7 +22,7 @@ def service_active(service_name: str) -> bool:
 
 
 def install_apt_packages(package_list: List[str]) -> None:
-    """Install apt package ca-certificates package."""
+    """Installs a given list of packages."""
     package_list_str = " ".join(package_list)
     shell("sudo apt -qq update")
     shell(f"sudo apt -y install {package_list_str}")

--- a/src/utils.py
+++ b/src/utils.py
@@ -38,12 +38,12 @@ def git_clone(
     """Runs git clone of a given repo."""
     command = "git clone"
     if branch:
-        command = command + f" --branch={branch}"
+        command = f"{command} --branch={branch}"
     if depth:
-        command = command + f" --depth={depth}"
-    command = command + " " + repo
+        command = f"{command} --depth={depth}"
+    command = f"{command} {repo}"
     if output_folder:
-        command = command + " " + output_folder
+        command = f"{command} {output_folder}"
     shell(command)
     logger.info("Cloned git repository")
 

--- a/src/utils.py
+++ b/src/utils.py
@@ -97,7 +97,7 @@ def service_restart(service_name: str) -> None:
 def service_stop(service_name: str) -> None:
     """Stops a given service."""
     _systemctl("stop", service_name)
-    logger.info(f"Service {service_name} stopped")
+    logger.info("Service %s stopped", (service_name))
 
 
 def service_enable(service_name: str) -> None:

--- a/src/utils.py
+++ b/src/utils.py
@@ -103,7 +103,7 @@ def service_stop(service_name: str) -> None:
 def service_enable(service_name: str) -> None:
     """Enables a given service."""
     _systemctl("enable", service_name)
-    logger.info(f"Service {service_name} enabled")
+    logger.info("Service %s enabled", (service_name))
 
 
 def systemctl_daemon_reload() -> None:

--- a/src/utils.py
+++ b/src/utils.py
@@ -91,7 +91,7 @@ def service_start(service_name: str) -> None:
 def service_restart(service_name: str) -> None:
     """Restarts a given service."""
     _systemctl("restart", service_name)
-    logger.info(f"Service {service_name} restarted")
+    logger.info("Service %s restarted", (service_name))
 
 
 def service_stop(service_name: str) -> None:

--- a/src/utils.py
+++ b/src/utils.py
@@ -31,20 +31,12 @@ def install_apt_packages(package_list: List[str]) -> None:
 
 def git_clone(
     repo: str,
-    output_folder: str = None,
-    branch: str = None,
-    depth: int = None,
+    output_folder: str,
+    branch: str,
+    depth: int,
 ) -> None:
     """Runs git clone of a given repo."""
-    command = "git clone"
-    if branch:
-        command = f"{command} --branch={branch}"
-    if depth:
-        command = f"{command} --depth={depth}"
-    command = f"{command} {repo}"
-    if output_folder:
-        command = f"{command} {output_folder}"
-    shell(command)
+    shell(f"git clone --branch={branch} --depth={depth} {repo} {output_folder}")
     logger.info("Cloned git repository")
 
 

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -16,7 +16,7 @@ class MockOpen:
     def __init__(self, read_data: str = ""):
         """Init."""
         self.read_data = read_data
-        self.writen_data = None
+        self.written_data = None
 
     def __enter__(self):
         """Enter."""

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -151,11 +151,7 @@ class TestCharm(unittest.TestCase):
     @patch("shutil.rmtree")
     @patch("subprocess.run")
     def test_given_service_template_when_install_then_srsenb_service_file_is_rendered(
-        self,
-        _,
-        __,
-        ___,
-        ____,
+        self, _, __, ___, ____
     ):
 
         with open("templates/srsenb.service", "r") as f:

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -2,8 +2,245 @@
 # See LICENSE file for licensing details.
 
 import unittest
+from unittest.mock import call, mock_open, patch
+
+from ops import testing
+
+from charm import SrsLteCharm
+
+testing.SIMULATE_CAN_CONNECT = True
+
+
+class MockOpen:
+    def __init__(self, read_data: str = ""):
+        """Init."""
+        self.read_data = read_data
+        self.writen_data = None
+
+    def __enter__(self):
+        """Enter."""
+        return self
+
+    def read(self):
+        """Read."""
+        return self.read_data
+
+    def write(self, data: str):
+        """Write."""
+        self.writen_data = data
+
+    def __exit__(self, *args):
+        """Exit."""
+        pass
 
 
 class TestCharm(unittest.TestCase):
-    def test_given_when_then(self):
-        pass
+    def setUp(self) -> None:
+        self.harness = testing.Harness(SrsLteCharm)
+        self.addCleanup(self.harness.cleanup)
+        self.harness.begin()
+
+    @patch("builtins.open", new_callable=mock_open)
+    @patch("os.mkdir")
+    @patch("shutil.copy")
+    @patch("shutil.rmtree")
+    @patch("subprocess.run")
+    def test_given_list_of_packages_to_install_when_install_then_apt_cache_is_updated(
+        self, patch_subprocess_run, _, __, ___, ____
+    ):
+
+        self.harness.charm.on.install.emit()
+
+        patch_subprocess_run.assert_any_call(
+            ["apt", "-qq", "update"], shell=True, stdout=-1, encoding="utf-8"
+        )
+
+    @patch("builtins.open", new_callable=mock_open)
+    @patch("os.mkdir")
+    @patch("shutil.copy")
+    @patch("shutil.rmtree")
+    @patch("subprocess.run")
+    def test_given_list_of_packages_to_install_when_install_then_apt_packages_are_installed(
+        self, patch_subprocess_run, _, __, ___, ____
+    ):
+        self.harness.charm.on.install.emit()
+
+        patch_subprocess_run.assert_any_call(
+            ["apt", "install", "git"], shell=True, stdout=-1, encoding="utf-8"
+        )
+        patch_subprocess_run.assert_any_call(
+            ["apt", "install", "libzmq3-dev"], shell=True, stdout=-1, encoding="utf-8"
+        )
+        patch_subprocess_run.assert_any_call(
+            ["apt", "install", "cmake"], shell=True, stdout=-1, encoding="utf-8"
+        )
+        patch_subprocess_run.assert_any_call(
+            ["apt", "install", "build-essential"], shell=True, stdout=-1, encoding="utf-8"
+        )
+        patch_subprocess_run.assert_any_call(
+            ["apt", "install", "libmbedtls-dev"], shell=True, stdout=-1, encoding="utf-8"
+        )
+        patch_subprocess_run.assert_any_call(
+            ["apt", "install", "libboost-program-options-dev"],
+            shell=True,
+            stdout=-1,
+            encoding="utf-8",
+        )
+        patch_subprocess_run.assert_any_call(
+            ["apt", "install", "libsctp-dev"], shell=True, stdout=-1, encoding="utf-8"
+        )
+        patch_subprocess_run.assert_any_call(
+            ["apt", "install", "libconfig++-dev"], shell=True, stdout=-1, encoding="utf-8"
+        )
+        patch_subprocess_run.assert_any_call(
+            ["apt", "install", "libfftw3-dev"], shell=True, stdout=-1, encoding="utf-8"
+        )
+        patch_subprocess_run.assert_any_call(
+            ["apt", "install", "net-tools"], shell=True, stdout=-1, encoding="utf-8"
+        )
+
+    @patch("builtins.open", new_callable=mock_open)
+    @patch("os.mkdir")
+    @patch("shutil.copy")
+    @patch("shutil.rmtree")
+    @patch("subprocess.run")
+    def test_given_install_event_when_install_then_srs_directories_are_removed_and_recreated(
+        self, _, patch_rmtree, __, patch_mkdir, ___
+    ):
+        self.harness.charm.on.install.emit()
+
+        rmtree_calls = [
+            call("/srsLTE", ignore_errors=True),
+            call("/build", ignore_errors=True),
+            call("/config", ignore_errors=True),
+            call("/service", ignore_errors=True),
+        ]
+        mkdir_calls = [call("/srsLTE"), call("/build"), call("/config"), call("/service")]
+        patch_rmtree.assert_has_calls(calls=rmtree_calls)
+        patch_mkdir.assert_has_calls(calls=mkdir_calls)
+
+    @patch("builtins.open", new_callable=mock_open)
+    @patch("os.mkdir")
+    @patch("shutil.copy")
+    @patch("shutil.rmtree")
+    @patch("subprocess.run")
+    def test_given_install_event_when_install_then_srsran_repo_is_cloned(
+        self, patch_subprocess_run, _, __, ___, ____
+    ):
+        self.harness.charm.on.install.emit()
+
+        patch_subprocess_run.assert_any_call(
+            [
+                "git",
+                "clone",
+                "--branch=release_20_10",
+                "--depth=1",
+                "https://github.com/srsLTE/srsLTE.git",
+                "/srsLTE",
+            ],
+            shell=True,
+            stdout=-1,
+            encoding="utf-8",
+        )
+
+    @patch("builtins.open", new_callable=mock_open)
+    @patch("os.mkdir")
+    @patch("shutil.copy")
+    @patch("shutil.rmtree")
+    @patch("subprocess.run")
+    def test_given_install_event_when_install_then_srsran_is_built(
+        self, patch_subprocess_run, _, __, ___, ____
+    ):
+        self.harness.charm.on.install.emit()
+
+        patch_subprocess_run.assert_any_call(
+            "cd /build && cmake /srsLTE && make -j `nproc` srsenb srsue",
+            shell=True,
+            stdout=-1,
+            encoding="utf-8",
+        )
+
+    @patch("builtins.open", new_callable=mock_open)
+    @patch("os.mkdir")
+    @patch("shutil.copy")
+    @patch("shutil.rmtree")
+    @patch("subprocess.run")
+    def test_given_install_event_when_install_then_files_are_copied(
+        self, _, __, patch_copy, ___, ____
+    ):
+        self.harness.charm.on.install.emit()
+
+        calls = [
+            call("/srsLTE/srsenb/enb.conf.example", "/config/enb.conf"),
+            call("/srsLTE/srsenb/drb.conf.example", "/config/drb.conf"),
+            call("/srsLTE/srsenb/rr.conf.example", "/config/rr.conf"),
+            call("/srsLTE/srsenb/sib.conf.example", "/config/sib.conf"),
+            call("/srsLTE/srsenb/sib.conf.mbsfn.example", "/config/sib.mbsfn.conf"),
+            call("/srsLTE/srsue/ue.conf.example", "/config/ue.conf"),
+        ]
+        patch_copy.assert_has_calls(calls=calls)
+
+    @patch("os.mkdir")
+    @patch("shutil.copy")
+    @patch("shutil.rmtree")
+    @patch("subprocess.run")
+    def test_given_service_template_when_install_then_srsenb_service_file_is_rendered(
+        self,
+        _,
+        __,
+        ___,
+        ____,
+    ):
+
+        with open("templates/srsenb.service", "r") as f:
+            srsenb_service_content = f.read()
+        with open("templates/srsue.service", "r") as f:
+            srsue_service_content = f.read()
+
+        with patch("builtins.open") as mock_open:
+            mock_open_read_srsenb_template = MockOpen(read_data=srsenb_service_content)
+            mock_open_write_srsenb_service = MockOpen()
+            mock_open_read_srsue_template = MockOpen(read_data=srsue_service_content)
+            mock_open_write_srsue_service = MockOpen()
+            mock_open.side_effect = [
+                mock_open_read_srsenb_template,
+                mock_open_write_srsenb_service,
+                mock_open_read_srsue_template,
+                mock_open_write_srsue_service,
+            ]
+            self.harness.charm.on.install.emit()
+
+        srsenb_expected_service = (
+            "[Unit]\n"
+            "Description=Srs EnodeB Service\n"
+            "After=network.target\n"
+            "StartLimitIntervalSec=0\n"
+            "[Service]\n"
+            "Type=simple\n"
+            "Restart=always\n"
+            "RestartSec=1\n"
+            "User=root\n"
+            "ExecStart=/build/srsenb/src/srsenb --enb.name=dummyENB01 --enb.mcc=901 --enb.mnc=70 --enb_files.rr_config=/config/rr.conf --enb_files.sib_config=/config/sib.conf --enb_files.drb_config=/config/drb.conf /config/enb.conf --rf.device_name=zmq --rf.device_args=fail_on_disconnect=true,tx_port=tcp://*:2000,rx_port=tcp://localhost:2001,id=enb,base_srate=23.04e6\n\n"  # noqa: E501, W505
+            "[Install]\n"
+            "WantedBy=multi-user.target"
+        )
+        srsue_expected_service = (
+            "[Unit]\n"
+            "Description=Srs User Emulator Service\n"
+            "After=network.target\n"
+            "StartLimitIntervalSec=0\n"
+            "[Service]\n"
+            "Type=simple\n"
+            "Restart=always\n"
+            "RestartSec=1\n"
+            "ExecStart=/build/srsue/src/srsue --usim.algo=milenage --nas.apn=oai.ipv4 --rf.device_name=zmq --rf.device_args=tx_port=tcp://*:2001,rx_port=tcp://localhost:2000,id=ue,base_srate=23.04e6 /config/ue.conf\n"  # noqa: E501, W505
+            "User=root\n"
+            "KillSignal=SIGINT\n"
+            "TimeoutStopSec=10\n"
+            "ExecStopPost=service srsenb restart\n\n"
+            "[Install]\n"
+            "WantedBy=multi-user.target"
+        )
+
+        assert mock_open_write_srsenb_service.writen_data == srsenb_expected_service
+        assert mock_open_write_srsue_service.writen_data == srsue_expected_service

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -208,8 +208,8 @@ class TestCharm(unittest.TestCase):
             "WantedBy=multi-user.target"
         )
 
-        assert mock_open_write_srsenb_service.writen_data == srsenb_expected_service
-        assert mock_open_write_srsue_service.writen_data == srsue_expected_service
+        assert mock_open_write_srsenb_service.written_data == srsenb_expected_service
+        assert mock_open_write_srsue_service.written_data == srsue_expected_service
 
     @patch("subprocess.run")
     def test_given_service_not_yet_started_when_on_start_then_srsenb_service_is_started(

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -52,7 +52,7 @@ class TestCharm(unittest.TestCase):
         self.harness.charm.on.install.emit()
 
         patch_subprocess_run.assert_any_call(
-            ["apt", "-qq", "update"], shell=True, stdout=-1, encoding="utf-8"
+            "sudo apt -qq update", shell=True, stdout=-1, encoding="utf-8"
         )
 
     @patch("builtins.open", new_callable=mock_open)
@@ -66,37 +66,10 @@ class TestCharm(unittest.TestCase):
         self.harness.charm.on.install.emit()
 
         patch_subprocess_run.assert_any_call(
-            ["apt", "install", "git"], shell=True, stdout=-1, encoding="utf-8"
-        )
-        patch_subprocess_run.assert_any_call(
-            ["apt", "install", "libzmq3-dev"], shell=True, stdout=-1, encoding="utf-8"
-        )
-        patch_subprocess_run.assert_any_call(
-            ["apt", "install", "cmake"], shell=True, stdout=-1, encoding="utf-8"
-        )
-        patch_subprocess_run.assert_any_call(
-            ["apt", "install", "build-essential"], shell=True, stdout=-1, encoding="utf-8"
-        )
-        patch_subprocess_run.assert_any_call(
-            ["apt", "install", "libmbedtls-dev"], shell=True, stdout=-1, encoding="utf-8"
-        )
-        patch_subprocess_run.assert_any_call(
-            ["apt", "install", "libboost-program-options-dev"],
+            "sudo apt -y install git libzmq3-dev cmake build-essential libmbedtls-dev libboost-program-options-dev libsctp-dev libconfig++-dev libfftw3-dev net-tools",  # noqa: E501
             shell=True,
             stdout=-1,
             encoding="utf-8",
-        )
-        patch_subprocess_run.assert_any_call(
-            ["apt", "install", "libsctp-dev"], shell=True, stdout=-1, encoding="utf-8"
-        )
-        patch_subprocess_run.assert_any_call(
-            ["apt", "install", "libconfig++-dev"], shell=True, stdout=-1, encoding="utf-8"
-        )
-        patch_subprocess_run.assert_any_call(
-            ["apt", "install", "libfftw3-dev"], shell=True, stdout=-1, encoding="utf-8"
-        )
-        patch_subprocess_run.assert_any_call(
-            ["apt", "install", "net-tools"], shell=True, stdout=-1, encoding="utf-8"
         )
 
     @patch("builtins.open", new_callable=mock_open)
@@ -130,14 +103,7 @@ class TestCharm(unittest.TestCase):
         self.harness.charm.on.install.emit()
 
         patch_subprocess_run.assert_any_call(
-            [
-                "git",
-                "clone",
-                "--branch=release_20_10",
-                "--depth=1",
-                "https://github.com/srsLTE/srsLTE.git",
-                "/srsLTE",
-            ],
+            "git clone --branch=release_20_10 --depth=1 https://github.com/srsLTE/srsLTE.git /srsLTE",  # noqa: E501
             shell=True,
             stdout=-1,
             encoding="utf-8",

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -49,7 +49,6 @@ class TestCharm(unittest.TestCase):
     def test_given_list_of_packages_to_install_when_install_then_apt_cache_is_updated(
         self, patch_subprocess_run, _, __, ___, ____
     ):
-
         self.harness.charm.on.install.emit()
 
         patch_subprocess_run.assert_any_call(

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -28,7 +28,7 @@ class MockOpen:
 
     def write(self, data: str):
         """Write."""
-        self.writen_data = data
+        self.written_data = data
 
     def __exit__(self, *args):
         """Exit."""

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -263,3 +263,14 @@ class TestCharm(unittest.TestCase):
             ]
         )
 
+    @patch("subprocess.run")
+    @patch("builtins.open", new_callable=mock_open)
+    def test_given_any_config_when_on_config_changed_then_systemd_manager_configuration_is_reloaded(  # noqa: E501
+        self, _, patch_run
+    ):
+        key_values = {}
+        self.harness.update_config(key_values=key_values)
+
+        patch_run.assert_any_call(
+            "systemctl daemon-reload", shell=True, stdout=-1, encoding="utf-8"
+        )


### PR DESCRIPTION
- Replaces use of `apt` python package with `shell`
  - Reason: `apt` doesn't work on virtual environments. It makes it hard to test the charm using `tox`.
- Adds unit tests for install, start and stop events.