### PR TITLE
Use strictly confined snap

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -148,7 +148,10 @@ class SrsRANCharm(CharmBase):
     @staticmethod
     def _install_srsran() -> None:
         """Installs srsRAN snap."""
-        shell("snap install srsran --edge --devmode")
+        shell("snap install srsran --edge")
+        shell("snap connect srsran:network-control")
+        shell("snap connect srsran:process-control")
+        shell("snap connect srsran:system-observe")
         logger.info("Installed srsRAN snap")
 
     @staticmethod

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -47,7 +47,14 @@ class TestCharm(unittest.TestCase):
 
         self.harness.charm.on.install.emit()
 
-        patch_shell.assert_called_with("snap install srsran --edge --devmode")
+        patch_shell.assert_has_calls(
+            [
+                call("snap install srsran --edge"),
+                call("snap connect srsran:network-control"),
+                call("snap connect srsran:process-control"),
+                call("snap connect srsran:system-observe"),
+            ]
+        )
 
     @patch("charm.shell", new=Mock())
     def test_given_unit_is_leader_when_install_then_status_is_maintenance(self):


### PR DESCRIPTION
# Description

Uses the new version strictly confined version of the `srsran` snap.

Depends on: https://github.com/canonical/srsran-snap/pull/14

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project.
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
- [x] I have added tests that validate the behaviour of the software.
- [x] I validated that new and existing unit tests pass locally with my changes.
- [x] Any dependent changes have been merged and published in downstream modules.